### PR TITLE
feat: github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release & Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - run: npm ci
+        working-directory: cli
+
+      - run: npm test
+        working-directory: cli
+
+  release:
+    name: Release & Publish
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify package.json version matches tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "${{ steps.version.outputs.VERSION }}" ]; then
+            echo "Package version ($PKG_VERSION) does not match tag (${{ steps.version.outputs.VERSION }})"
+            exit 1
+          fi
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$PREVIOUS_TAG" ]; then
+            COMMITS=$(git log "$PREVIOUS_TAG"..HEAD --pretty=format:"- %s (%h)" --no-merges)
+          else
+            COMMITS=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
+          fi
+          {
+            echo "CHANGELOG<<EOF"
+            echo "## What's Changed"
+            echo ""
+            echo "$COMMITS"
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${{ github.ref_name }}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: context.refName,
+              name: `Release ${{ steps.version.outputs.VERSION }}`,
+              body: `${{ steps.changelog.outputs.CHANGELOG }}`,
+              draft: false,
+              prerelease: false
+            });
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm ci
         working-directory: cli
 
-      - run: npm test
+      - run: npm run test:all
         working-directory: cli
 
   release:


### PR DESCRIPTION
 Summary         
  - Adds a release.yml GitHub Actions workflow triggered by version tags (v*)
  - Runs tests, builds the package, creates a GitHub Release with auto-generated changelog, and
  publishes to npm
  - Includes a version verification step to ensure the git tag matches package.json

  Details

  The workflow has two jobs:

  1. Test — runs npm ci and npm test to validate the package
  2. Release & Publish — runs after tests pass:
    - Builds the CLI with npm run build                                                                
    - Verifies package.json version matches the pushed tag (prevents accidental mismatches)
    - Generates a changelog from git commits since the previous tag                                    
    - Creates a GitHub Release via the API
    - Publishes @appritech/postkit to npm with provenance (--provenance --access public)

  Usage:
  # Bump version in cli/package.json, then:
  git tag v1.0.9                           
  git push origin v1.0.9
                        
  Required secret: NPM_TOKEN must be configured in the repository's Actions secrets.
                                                                                                       