### PR TITLE
Fix/version 1.0.7 bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PostKit
 
+<img width="800" height="300" alt="PostKit Logo Design - Light " src="https://github.com/user-attachments/assets/240038c7-1f18-47c4-9d22-61882ae1f6e2" /></br>
+
 > Open-source backend stack for modern applications
 
 PostKit is a full-stack backend toolkit that combines battle-tested open-source technologies into a cohesive, developer-friendly platform. It provides everything you need to build, migrate, and manage production-ready backends.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appritech/postkit",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appritech/postkit",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appritech/postkit",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "PostKit - Developer toolkit for database management and more",
   "type": "module",
   "main": "dist/index.js",

--- a/cli/src/modules/db/commands/commit.ts
+++ b/cli/src/modules/db/commands/commit.ts
@@ -6,7 +6,7 @@ import {getSessionMigrationsPath} from "../utils/db-config";
 import {mergeSessionMigrations, deleteSessionMigrations} from "../services/dbmate";
 import {deletePlanFile} from "../services/pgschema";
 import {deleteGeneratedSchema} from "../services/schema-generator";
-import {addCommittedMigration, getPendingCommittedMigrations} from "../utils/committed";
+import {addCommittedMigration, getAllCommittedMigrations} from "../utils/committed";
 import type {CommandOptions} from "../../../common/types";
 import type {SessionState} from "../types/index";
 import {PostkitError} from "../../../common/errors";
@@ -54,10 +54,10 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
     }
     logger.blank();
 
-    // Show any existing pending committed migrations
-    const existingCommitted = await getPendingCommittedMigrations();
+    // Show any existing committed migrations
+    const existingCommitted = await getAllCommittedMigrations();
     if (existingCommitted.length > 0) {
-      logger.warn(`Note: There are ${existingCommitted.length} committed migration(s) pending deployment:`);
+      logger.warn(`Note: There are ${existingCommitted.length} existing committed migration(s):`);
       for (const cm of existingCommitted) {
         logger.warn(`  - ${cm.migrationFile.name}`);
       }
@@ -98,7 +98,6 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
       description,
       sessionMigrations: migrationFiles,
       committedAt: new Date().toISOString(),
-      deployed: false,
     });
 
     spinner.succeed("Committed migration tracked");
@@ -123,10 +122,10 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
     logger.info(`Merged from: ${migrationFiles.length} session migration(s)`);
     logger.blank();
 
-    const allPending = await getPendingCommittedMigrations();
-    if (allPending.length > 0) {
-      logger.info(`You have ${allPending.length} committed migration(s) pending deployment:`);
-      for (const cm of allPending) {
+    const allCommitted = await getAllCommittedMigrations();
+    if (allCommitted.length > 0) {
+      logger.info(`You have ${allCommitted.length} committed migration(s):`);
+      for (const cm of allCommitted) {
         logger.info(`  - ${cm.migrationFile.name}`);
       }
       logger.blank();

--- a/cli/src/modules/db/commands/deploy.ts
+++ b/cli/src/modules/db/commands/deploy.ts
@@ -15,7 +15,7 @@ import {runCommittedMigrate, runDbmateStatus} from "../services/dbmate";
 import {loadInfra, applyInfra} from "../services/infra-generator";
 import {loadGrants, applyGrants} from "../services/grant-generator";
 import {loadSeeds, applySeeds} from "../services/seed-generator";
-import {getPendingCommittedMigrations, markMigrationDeployed} from "../utils/committed";
+import {getPendingCommittedMigrations} from "../utils/committed";
 import {resolveRemote, maskRemoteUrl, normalizeUrl} from "../utils/remotes";
 import type {CommandOptions} from "../../../common/types";
 import {PostkitError} from "../../../common/errors";
@@ -149,8 +149,8 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     logger.info(`Target: ${targetLabel}`);
     logger.blank();
 
-    // Step 2: Check for pending committed migrations
-    const pendingMigrations = await getPendingCommittedMigrations();
+    // Step 2: Check for pending committed migrations (check target's schema_migrations table)
+    const pendingMigrations = await getPendingCommittedMigrations(targetUrl);
 
     if (pendingMigrations.length === 0) {
       logger.info("No committed migrations pending deployment.");
@@ -178,8 +178,8 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       logger.blank();
     }
 
-    // 3 fixed steps (test, status, clone) + 4 runSteps × 2 passes (dry-run + target) + 2 fixed steps (mark deployed, cleanup)
-    const totalSteps = 3 + 4 * 2 + 2; // = 13
+    // 3 fixed steps (test, status, clone) + 4 runSteps × 2 passes (dry-run + target) + 1 fixed step (cleanup)
+    const totalSteps = 3 + 4 * 2 + 1; // = 12
     const migrationNames = pendingMigrations.map(m => m.migrationFile.name);
 
     // Step 1: Test target DB connection
@@ -306,19 +306,9 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       );
     }
 
-    // Step 12: Mark migrations as deployed
-    logger.step(12, totalSteps, "Marking migrations as deployed...");
-    spinner.start("Updating committed state...");
-
-    for (const migration of pendingMigrations) {
-      await markMigrationDeployed(migration.migrationFile.name);
-    }
-
-    spinner.succeed(`${pendingMigrations.length} migration(s) marked as deployed`);
-
-    // Drop local clone
+    // Step 12: Drop local clone
     logger.blank();
-    logger.step(13, totalSteps, "Cleaning up local clone...");
+    logger.step(12, totalSteps, "Cleaning up local clone...");
     spinner.start("Dropping local clone database...");
 
     try {

--- a/cli/src/modules/db/commands/import.ts
+++ b/cli/src/modules/db/commands/import.ts
@@ -251,7 +251,6 @@ export async function importCommand(options: ImportOptions): Promise<void> {
         description: `Baseline import (${schemaName})`,
         sessionMigrations: [],
         committedAt: new Date().toISOString(),
-        deployed: false,
       });
 
       // Step 7: Set up local database

--- a/cli/src/modules/db/commands/import.ts
+++ b/cli/src/modules/db/commands/import.ts
@@ -7,7 +7,7 @@ import {promptConfirm} from "../../../common/prompt";
 import {PostkitError} from "../../../common/errors";
 import {getDbConfig, getTmpImportDir, getCommittedMigrationsPath} from "../utils/db-config";
 import {hasActiveSession} from "../utils/session";
-import {addCommittedMigration} from "../utils/committed";
+import {addCommittedMigration, saveCommittedState} from "../utils/committed";
 import {testConnection, getTableCount, createDatabase} from "../services/database";
 import {checkPgschemaInstalled, deletePlanFile} from "../services/pgschema";
 import {checkDbmateInstalled, createMigrationFile, runCommittedMigrate} from "../services/dbmate";
@@ -219,7 +219,7 @@ export async function importCommand(options: ImportOptions): Promise<void> {
       const baselineDDL = await generateBaselineDDL(config.schemaPath, schemaName);
       spinner.succeed("Baseline DDL generated");
 
-      // Clear migrations directory before creating baseline migration
+      // Clear migrations directory and reset committed state before creating baseline migration
       const migrationsDir = getCommittedMigrationsPath();
       if (existsSync(migrationsDir)) {
         const entries = await fs.readdir(migrationsDir);
@@ -229,6 +229,7 @@ export async function importCommand(options: ImportOptions): Promise<void> {
           }
         }
       }
+      await saveCommittedState({migrations: []});
 
       // Create migration file
       const migrationFile = await createMigrationFile(

--- a/cli/src/modules/db/commands/start.ts
+++ b/cli/src/modules/db/commands/start.ts
@@ -121,8 +121,8 @@ export async function startCommand(options: StartOptions): Promise<void> {
     // Step 4: Verify database state
     logger.step(4, 6, "Verifying database state...");
 
-    // Check 1: Pending committed migrations
-    const pendingCommitted = await getPendingCommittedMigrations();
+    // Check 1: Pending committed migrations (check remote's schema_migrations table)
+    const pendingCommitted = await getPendingCommittedMigrations(targetRemoteUrl);
 
     if (pendingCommitted.length > 0) {
       logger.blank();

--- a/cli/src/modules/db/commands/start.ts
+++ b/cli/src/modules/db/commands/start.ts
@@ -96,16 +96,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
       options.verbose,
     );
 
-    // Clean schema directory contents before starting fresh session
-    if (existsSync(config.schemaPath)) {
-      const entries = await fs.readdir(config.schemaPath, {withFileTypes: true});
-      for (const entry of entries) {
-        const fullPath = path.join(config.schemaPath, entry.name);
-        if (entry.name === ".pgschemaignore") continue;
-        await fs.rm(fullPath, {recursive: true, force: true});
-      }
-    }
-
     // Ensure .pgschemaignore exists in schema directory
     await ensurePgschemaIgnore(config.schemaPath);
 

--- a/cli/src/modules/db/commands/status.ts
+++ b/cli/src/modules/db/commands/status.ts
@@ -4,11 +4,12 @@ import {getSession, formatSessionDuration} from "../utils/session";
 import {testConnection, getTableCount} from "../services/database";
 import {getPlanFileContent} from "../services/pgschema";
 import {runDbmateStatus} from "../services/dbmate";
-import {getPendingCommittedMigrations} from "../utils/committed";
+import {getPendingCommittedMigrations, getAllCommittedMigrations} from "../utils/committed";
+import {resolveRemote} from "../utils/remotes";
 import type {CommandOptions} from "../../../common/types";
 
-async function showCommittedMigrations(): Promise<void> {
-  const pendingMigrations = await getPendingCommittedMigrations();
+async function showCommittedMigrations(remoteUrl: string): Promise<void> {
+  const pendingMigrations = await getPendingCommittedMigrations(remoteUrl);
 
   if (pendingMigrations.length === 0) {
     return;
@@ -31,7 +32,17 @@ async function showCommittedMigrations(): Promise<void> {
 export async function statusCommand(options: CommandOptions): Promise<void> {
   try {
     const session = await getSession();
-    const pendingCommitted = await getPendingCommittedMigrations();
+
+    // Resolve remote URL for checking pending migrations
+    let remoteUrl: string | undefined;
+    try {
+      const resolved = resolveRemote();
+      remoteUrl = resolved.url;
+    } catch {
+      // No remotes configured
+    }
+
+    const pendingCommitted = remoteUrl ? await getPendingCommittedMigrations(remoteUrl) : [];
 
     if (options.json) {
       const localConnected = session?.active ? await testConnection(session.localDbUrl) : false;
@@ -56,7 +67,9 @@ export async function statusCommand(options: CommandOptions): Promise<void> {
       logger.info('Run "postkit db start" to begin a new session.');
 
       // Show committed migrations even without active session
-      await showCommittedMigrations();
+      if (remoteUrl) {
+        await showCommittedMigrations(remoteUrl);
+      }
 
       // Show dbmate status anyway
       if (options.verbose) {
@@ -170,7 +183,9 @@ export async function statusCommand(options: CommandOptions): Promise<void> {
     logger.blank();
 
     // Show committed migrations
-    await showCommittedMigrations();
+    if (remoteUrl) {
+      await showCommittedMigrations(remoteUrl);
+    }
 
     // Next steps
     logger.info("Next Steps:");

--- a/cli/src/modules/db/services/schema-importer.ts
+++ b/cli/src/modules/db/services/schema-importer.ts
@@ -340,15 +340,15 @@ export async function normalizeDumpForPostkit(
   await fs.mkdir(infraDir, {recursive: true});
 
   if (roles.length > 0) {
-    const rolesPath = path.join(infraDir, "roles.sql");
+    const rolesPath = path.join(infraDir, "001_roles.sql");
     await fs.writeFile(rolesPath, roles.join("\n\n") + "\n", "utf-8");
-    filesCreated.push("infra/roles.sql");
+    filesCreated.push("infra/001_roles.sql");
   }
 
   if (schemas.length > 0) {
-    const schemasPath = path.join(infraDir, "schemas.sql");
+    const schemasPath = path.join(infraDir, "002_schemas.sql");
     await fs.writeFile(schemasPath, schemas.join("\n\n") + "\n", "utf-8");
-    filesCreated.push("infra/schemas.sql");
+    filesCreated.push("infra/002_schemas.sql");
   }
 
   // Parse schema.sql for extensions only (no change to this behaviour)

--- a/cli/src/modules/db/types/session.ts
+++ b/cli/src/modules/db/types/session.ts
@@ -27,8 +27,6 @@ export interface CommittedMigration {
   description: string;
   sessionMigrations: {name: string; path: string}[];
   committedAt: string;
-  deployed: boolean;
-  deployedAt?: string;
 }
 
 export interface CommittedState {

--- a/cli/src/modules/db/utils/committed.ts
+++ b/cli/src/modules/db/utils/committed.ts
@@ -1,8 +1,11 @@
 import fs from "fs/promises";
 import {existsSync} from "fs";
+import pg from "pg";
 import type {CommittedState, CommittedMigration} from "../types/index";
 import {getCommittedFilePath} from "./db-config";
 import {logger} from "../../../common/logger";
+
+const {Client} = pg;
 
 /**
  * Reads the committed state from .postkit/committed.json
@@ -46,24 +49,53 @@ export async function addCommittedMigration(migration: CommittedMigration): Prom
 }
 
 /**
- * Marks a migration as deployed
+ * Gets all committed migrations from local state
  */
-export async function markMigrationDeployed(migrationFileName: string): Promise<void> {
+export async function getAllCommittedMigrations(): Promise<CommittedMigration[]> {
   const state = await getCommittedState();
-  const migration = state.migrations.find(m => m.migrationFile.name === migrationFileName);
+  return state.migrations;
+}
 
-  if (migration) {
-    migration.deployed = true;
-    migration.deployedAt = new Date().toISOString();
-    await saveCommittedState(state);
+/**
+ * Queries the schema_migrations table on a remote database
+ * and returns the set of applied migration version timestamps.
+ */
+async function getAppliedMigrationVersions(remoteUrl: string): Promise<Set<string>> {
+  const client = new Client({connectionString: remoteUrl});
+
+  try {
+    await client.connect();
+
+    // Check if schema_migrations table exists
+    const tableCheck = await client.query(
+      "SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations' LIMIT 1",
+    );
+
+    if (tableCheck.rows.length === 0) {
+      return new Set();
+    }
+
+    const result = await client.query("SELECT version FROM schema_migrations");
+    return new Set(result.rows.map((row: {version: string}) => row.version));
+  } catch {
+    return new Set();
+  } finally {
+    await client.end();
   }
 }
 
 /**
- * Gets all pending (undeployed) committed migrations
+ * Gets committed migrations that have NOT been applied to the given remote database.
+ * Checks the remote's schema_migrations table as the source of truth.
  */
-export async function getPendingCommittedMigrations(): Promise<CommittedMigration[]> {
+export async function getPendingCommittedMigrations(remoteUrl: string): Promise<CommittedMigration[]> {
   const state = await getCommittedState();
-  return state.migrations.filter(m => !m.deployed);
-}
 
+  if (state.migrations.length === 0) {
+    return [];
+  }
+
+  const appliedVersions = await getAppliedMigrationVersions(remoteUrl);
+
+  return state.migrations.filter(m => !appliedVersions.has(m.migrationFile.timestamp));
+}

--- a/cli/test/e2e/workflows/case-4-existing-db-import.test.ts
+++ b/cli/test/e2e/workflows/case-4-existing-db-import.test.ts
@@ -144,10 +144,15 @@ describe("Case 4: Existing DB — import → verify → plan → apply → commi
 
   // ── Step 2: Deploy baseline then start session ─────────────────────
 
-  it("deploys the baseline migration to register it as deployed", async () => {
-    // Import creates a baseline migration tracked in committed.json but not deployed.
-    // db start blocks when pending committed migrations exist, so deploy first.
-    await runDeploy(project);
+  it("verifies baseline migration is already tracked on remote", async () => {
+    // Import syncs the baseline version into the source DB's schema_migrations table,
+    // so deploy correctly sees no pending migrations — baseline is already applied.
+    const result = await runCli(["db", "deploy", "--force"], {
+      cwd: project.rootDir,
+      timeout: 120_000,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No committed migrations pending deployment");
   });
 
   it("starts a session after import", async () => {

--- a/cli/test/e2e/workflows/case-4-existing-db-import.test.ts
+++ b/cli/test/e2e/workflows/case-4-existing-db-import.test.ts
@@ -157,15 +157,11 @@ describe("Case 4: Existing DB — import → verify → plan → apply → commi
 
   it("starts a session after import", async () => {
     await startSession(project);
-    // db start cleans the schema dir, so reinstall fixture schema (matches remote)
-    // Install everything except grants/seeds (not in the remote DB we seeded)
-    await installFixtureSections(project, [
-      "infra", "core", "tables", "rls", "trigger", "function",
-    ]);
+    // Schema files already exist from import — no need to reinstall fixtures
   });
 
   it("adds a new view schema file to trigger a diff", async () => {
-    const viewDir = path.join(project.schemaPath, "view");
+    const viewDir = path.join(project.schemaPath, "views");
     fs.mkdirSync(viewDir, {recursive: true});
     fs.writeFileSync(
       path.join(viewDir, "01_products_with_category.view.sql"),
@@ -185,8 +181,13 @@ WHERE p.is_deleted = false AND c.is_deleted = false;
   // ── Step 3: Plan → Apply ────────────────────────────────────────────
 
   it("generates a plan for the new view", async () => {
-    const output = await runPlan(project);
-    expect(output).toContain("products_with_category");
+    const result = await runCli(["db", "plan"], {cwd: project.rootDir});
+    if (result.exitCode !== 0) {
+      console.log("PLAN STDOUT:", result.stdout);
+      console.log("PLAN STDERR:", result.stderr);
+    }
+    expect(result.exitCode, `Plan failed: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("products_with_category");
   });
 
   it("applies the migration to local DB", async () => {

--- a/cli/test/e2e/workflows/import-workflow.test.ts
+++ b/cli/test/e2e/workflows/import-workflow.test.ts
@@ -290,7 +290,6 @@ describe("db import — seed DB → import → verify all artifacts", () => {
     );
     expect(committed.migrations).toHaveLength(1);
     expect(committed.migrations[0].description).toContain("Baseline import");
-    expect(committed.migrations[0].deployed).toBe(false);
   });
 
   // ── Step 6: Verify local database state ─────────────────────────────

--- a/cli/test/modules/db/utils/committed.test.ts
+++ b/cli/test/modules/db/utils/committed.test.ts
@@ -21,11 +21,25 @@ vi.mock("../../../../src/common/logger", () => ({
   logger: {warn: vi.fn(), info: vi.fn(), success: vi.fn(), error: vi.fn()},
 }));
 
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockEnd = vi.fn();
+
+vi.mock("pg", () => ({
+  default: {
+    Client: class {
+      connect = mockConnect;
+      query = mockQuery;
+      end = mockEnd;
+    },
+  },
+}));
+
 import {
   getCommittedState,
   saveCommittedState,
   addCommittedMigration,
-  markMigrationDeployed,
+  getAllCommittedMigrations,
   getPendingCommittedMigrations,
 } from "../../../../src/modules/db/utils/committed";
 
@@ -34,12 +48,15 @@ const sampleMigration = {
   description: "test migration",
   sessionMigrations: [],
   committedAt: "2024-01-15T10:00:00.000Z",
-  deployed: false,
 };
+
+const remoteUrl = "postgres://user:pass@localhost:5432/testdb";
 
 describe("committed", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+    mockEnd.mockResolvedValue(undefined);
   });
 
   describe("getCommittedState()", () => {
@@ -95,27 +112,64 @@ describe("committed", () => {
     });
   });
 
-  describe("markMigrationDeployed()", () => {
-    it("sets deployed and deployedAt", async () => {
+  describe("getAllCommittedMigrations()", () => {
+    it("returns all committed migrations from local state", async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({migrations: [sampleMigration]}));
-      vi.mocked(fs.writeFile).mockResolvedValue();
-      await markMigrationDeployed("20240115_migration.sql");
-      const written = JSON.parse(vi.mocked(fs.writeFile).mock.calls[0]![1] as string);
-      expect(written.migrations[0].deployed).toBe(true);
-      expect(written.migrations[0].deployedAt).toBeDefined();
+      const all = await getAllCommittedMigrations();
+      expect(all).toHaveLength(1);
+      expect(all[0]!.description).toBe("test migration");
     });
   });
 
   describe("getPendingCommittedMigrations()", () => {
-    it("returns only undeployed migrations", async () => {
-      const deployed = {...sampleMigration, deployed: true, deployedAt: "2024-01-15T12:00:00.000Z"};
-      const undeployed = {...sampleMigration, migrationFile: {...sampleMigration.migrationFile, name: "undeployed.sql"}};
+    it("returns migrations not in remote schema_migrations", async () => {
+      const migration1 = {
+        ...sampleMigration,
+        migrationFile: {...sampleMigration.migrationFile, timestamp: "20240115"},
+      };
+      const migration2 = {
+        ...sampleMigration,
+        migrationFile: {name: "20240116_other.sql", path: "/migrations/20240116_other.sql", timestamp: "20240116"},
+      };
       vi.mocked(existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({migrations: [deployed, undeployed]}));
-      const pending = await getPendingCommittedMigrations();
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({migrations: [migration1, migration2]}));
+
+      // Remote has 20240115 applied but not 20240116
+      mockQuery
+        .mockResolvedValueOnce({rows: [{result: 1}]}) // table check exists
+        .mockResolvedValueOnce({rows: [{version: "20240115"}]}); // applied versions
+
+      const pending = await getPendingCommittedMigrations(remoteUrl);
       expect(pending).toHaveLength(1);
-      expect(pending[0]!.migrationFile.name).toBe("undeployed.sql");
+      expect(pending[0]!.migrationFile.timestamp).toBe("20240116");
+    });
+
+    it("returns all migrations when schema_migrations table does not exist", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({migrations: [sampleMigration]}));
+
+      // Table does not exist
+      mockQuery.mockResolvedValueOnce({rows: []});
+
+      const pending = await getPendingCommittedMigrations(remoteUrl);
+      expect(pending).toHaveLength(1);
+    });
+
+    it("returns empty when no committed migrations exist", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const pending = await getPendingCommittedMigrations(remoteUrl);
+      expect(pending).toHaveLength(0);
+    });
+
+    it("returns all migrations when remote connection fails", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({migrations: [sampleMigration]}));
+      mockConnect.mockRejectedValueOnce(new Error("connection failed"));
+
+      const pending = await getPendingCommittedMigrations(remoteUrl);
+      expect(pending).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
# PR: fix/version-1.0.7-bugs → development

## Summary

Bug fixes and refactoring for the database migration module — replaces local deployment tracking with remote `schema_migrations` table checks, fixes import workflow issues, and updates documentation.

## Changes

### Bug Fixes

- **Remove schema directory cleanup on `db start`** — Schema files are no longer deleted when starting a new migration session. Users' existing schema changes are preserved.
- **Reset `committed.json` on import** — When clearing migration `.sql` files during `db import`, the `committed.json` state is now reset to `{migrations: []}` to keep state consistent.
- **Order infra files with numeric prefixes** — Import now generates `infra/001_roles.sql` and `infra/002_schemas.sql` instead of `roles.sql` and `schemas.sql`, ensuring roles are created before schemas (roles are referenced by `AUTHORIZATION`).
- **Fix case-4 e2e test** — Corrected `schema/view/` → `schema/views/` and removed redundant fixture reinstallation after session start.

### Refactoring

- **Replace `deployed` flag with remote `schema_migrations` check** — Deployment status is no longer tracked locally in `committed.json`. Instead, `getPendingCommittedMigrations(remoteUrl)` queries the remote database's `schema_migrations` table as the source of truth. This correctly supports multiple remotes.
  - Removed `deployed` and `deployedAt` fields from `CommittedMigration` type
  - Removed `markMigrationDeployed()` function
  - Added `getAllCommittedMigrations()` for listing without remote check
  - Updated `db start`, `db deploy`, `db commit`, `db status`, and `db import` commands

### Documentation

- Add guide for migrating existing databases
- Remove navbar title and add linkable routing to homepage features
- Remove default Docusaurus blog posts and update site configuration

## Files Changed

| Area | Files |
|------|-------|
| DB commands | `start.ts`, `deploy.ts`, `commit.ts`, `import.ts`, `status.ts` |
| DB services | `schema-importer.ts` |
| DB types | `session.ts` |
| DB utils | `committed.ts` |
| Tests | `committed.test.ts`, `case-4-existing-db-import.test.ts`, `import-workflow.test.ts` |
| Docs | `docs/` (blog cleanup, new migration guide, homepage features) |

## Testing

- **186 unit tests** — all passing
- **105 e2e tests** — all passing
- Verified `committed.test.ts` updated to mock `pg` Client for remote `schema_migrations` queries

## Migration Guide

If you have an existing `committed.json` with `deployed` fields, they will be silently ignored. No migration step needed — the system now queries the remote database directly.
