### PR TITLE
 Move migration tracking to `postkit` schema & custom schema support

### DIFF
--- a/cli/docs/db.md
+++ b/cli/docs/db.md
@@ -196,7 +196,7 @@ All PostKit runtime files are stored in `.postkit/` (gitignored):
 
 ### `postkit db start [--remote <name>]`
 
-Clone a remote database to local and initialize a migration session.
+Clone a remote database to local and initialize a migration session. Existing schema files are preserved.
 
 ```bash
 postkit db start                    # Uses default remote
@@ -206,9 +206,10 @@ postkit db start --remote staging   # Use specific remote
 **What it does:**
 1. Checks prerequisites (pgschema, dbmate installed)
 2. Resolves target remote (default or specified)
-3. Tests connection to remote database
-4. Clones remote database to local using `pg_dump` and `psql`
-5. Creates a session file (`.postkit/db/session.json`) to track state
+3. Checks for pending committed migrations by querying the remote's `postkit.schema_migrations` table
+4. Tests connection to remote database
+5. Clones remote database to local using `pg_dump` and `psql`
+6. Creates a session file (`.postkit/db/session.json`) to track state
 
 ---
 
@@ -283,15 +284,15 @@ postkit db deploy --dry-run              # Verify only, don't touch target
 
 **What it does:**
 1. Resolves the target database URL (from remote config or `--url` flag)
-2. If an active session exists, removes it (with confirmation unless `-f`)
-3. Tests the target database connection
-4. Clones the target database to local (using `LOCAL_DATABASE_URL`)
-5. Runs a full dry-run on the local clone: infra, dbmate migrate, grants, seeds
-6. If `--dry-run` is set, stops here and reports results without touching the target
-7. Reports dry-run results and confirms deployment (unless `-f`)
-8. Applies to target: infra, dbmate migrate, grants, seeds
-9. Drops the local clone database
-10. Marks migrations as deployed in `.postkit/db/committed.json`
+2. Checks for pending committed migrations by querying the remote's `postkit.schema_migrations` table
+3. If an active session exists, removes it (with confirmation unless `-f`)
+4. Tests the target database connection
+5. Clones the target database to local (using `LOCAL_DATABASE_URL`)
+6. Runs a full dry-run on the local clone: infra, dbmate migrate, grants, seeds
+7. If `--dry-run` is set, stops here and reports results without touching the target
+8. Reports dry-run results and confirms deployment (unless `-f`)
+9. Applies to target: infra, dbmate migrate, grants, seeds
+10. Drops the local clone database
 
 If the dry run fails, deployment is aborted and no changes are made to the target database.
 
@@ -368,17 +369,18 @@ postkit db import --schema myschema --name initial_baseline
 2. Connects to target database, reports table count
 3. Warns about existing schema/migration files (both directories will be **cleared and replaced**), prompts confirmation
 4. Runs `pgschema dump --multi-file` into a temp directory
-5. Clears existing schema directory and normalizes dump into PostKit schema directory structure:
-   - Roles queried directly from `pg_roles` → `infra/roles.sql` (idempotent `DO $$ IF NOT EXISTS $$`)
-   - Schemas queried directly from `pg_namespace` → `infra/schemas.sql` (`CREATE SCHEMA IF NOT EXISTS`)
+5. Clears existing schema directory and resets `committed.json`, then normalizes dump into PostKit schema directory structure:
+   - Roles queried directly from `pg_roles` → `infra/001_roles.sql` (idempotent `DO $$ IF NOT EXISTS $$`)
+   - Schemas queried directly from `pg_namespace` → `infra/002_schemas.sql` (`CREATE SCHEMA IF NOT EXISTS`)
    - Extensions parsed from `schema.sql` → `extensions/imported_extensions.sql`
    - Privileges consolidated into `grants/<schema>.sql`
    - All SQL files are prefixed with numeric ordering (`001_filename.sql`) based on `schema.sql` `\i` directives
 6. Clears existing migrations directory and generates baseline DDL via `pgschema plan` against an empty temp database
-7. Creates local database, applies infrastructure SQL (roles, schemas), then applies baseline migration via `dbmate`
-8. After successful local apply, inserts baseline version into `schema_migrations` on the source database
-9. Updates `committed.json` to track the baseline migration
-10. Cleans up temp directory, plan file, and generated schema file
+7. For non-public schemas, prepends `SET search_path TO "<schema>"` to the baseline migration
+8. Creates local database, applies infrastructure SQL (roles, schemas), then applies baseline migration via `dbmate`
+9. After successful local apply, inserts baseline version into `postkit.schema_migrations` on the source database
+10. Updates `committed.json` to track the baseline migration
+11. Cleans up temp directory, plan file, and generated schema file
 
 **Why roles/schemas are queried from DB directly:**
 `pgschema dump` does not emit `CREATE SCHEMA` or `CREATE ROLE` statements. PostKit queries `pg_catalog.pg_namespace` and `pg_catalog.pg_roles` instead to reliably capture infra.
@@ -484,6 +486,29 @@ Session state is stored in `.postkit/db/session.json`:
 }
 ```
 
+### Committed Migrations (`committed.json`)
+
+Committed migrations are tracked in `.postkit/db/committed.json`. Deployment status is determined by querying the remote database's `postkit.schema_migrations` table — not stored locally.
+
+```json
+{
+  "migrations": [
+    {
+      "migrationFile": {
+        "name": "20260211_add_users.sql",
+        "path": ".postkit/db/migrations/20260211_add_users.sql",
+        "timestamp": "20260211120000"
+      },
+      "description": "Add users table",
+      "sessionMigrations": [
+        {"name": "20260211_120000_session.sql", "path": ".postkit/db/session/20260211_120000_session.sql"}
+      ],
+      "committedAt": "2026-02-11T12:00:00Z"
+    }
+  ]
+}
+```
+
 Session migrations are staged in `.postkit/db/session/` and committed migrations are stored in `.postkit/db/migrations/`.
 
 ---
@@ -502,6 +527,6 @@ Session migrations are staged in `.postkit/db/session/` and committed migrations
 | `Grants/seeds failed during apply` | Re-run `postkit db apply` — it resumes from where it left off |
 | `Deploy failed during dry run` | No changes were made to the target. Fix the issue and retry. |
 | `Import: pgschema plan produced no output` | Schema directory may be empty after normalization. Check that the source DB has objects in the target schema. |
-| `Import: Could not insert migration tracking record` | Non-fatal. The local DB migration succeeded but the source DB tracking record failed. Manually insert the version into `schema_migrations` on the source DB. |
+| `Import: Could not insert migration tracking record` | Non-fatal. The local DB migration succeeded but the source DB tracking record failed. Manually insert the version into `postkit.schema_migrations` on the source DB. |
 | `Import: column does not exist during local apply` | Infrastructure SQL (roles, schemas) may not have been applied to the local database before dbmate. Ensure `schema/infra/` files exist and are valid. |
 | `Import: relation does not exist during pgschema plan` | The `pgschema dump` ordering may not account for foreign key or policy dependencies. This is handled by pgschema internally. |

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appritech/postkit",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appritech/postkit",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appritech/postkit",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "PostKit - Developer toolkit for database management and more",
   "type": "module",
   "main": "dist/index.js",

--- a/cli/src/modules/db/commands/import.ts
+++ b/cli/src/modules/db/commands/import.ts
@@ -306,6 +306,11 @@ export async function importCommand(options: ImportOptions): Promise<void> {
       if (existsSync(tmpImportDir)) {
         await fs.rm(tmpImportDir, {recursive: true, force: true});
       }
+      // Clean up schema.sql artifact from baseline generation step
+      const artifact = path.join(path.dirname(config.schemaPath), "schema.sql");
+      if (existsSync(artifact)) {
+        await fs.unlink(artifact);
+      }
       await deletePlanFile();
       await deleteGeneratedSchema();
     }

--- a/cli/src/modules/db/config/queries.ts
+++ b/cli/src/modules/db/config/queries.ts
@@ -1,0 +1,59 @@
+import {MIGRATIONS_TABLE} from "../utils/db-config";
+
+// ============================================
+// Connection & Health Check
+// ============================================
+
+export const TEST_CONNECTION = "SELECT 1";
+
+export const CHECK_DB_EXISTS = "SELECT 1 FROM pg_database WHERE datname = $1";
+
+export const CREATE_POSTKIT_SCHEMA = "CREATE SCHEMA IF NOT EXISTS postkit";
+
+export const TERMINATE_CONNECTIONS = `
+  SELECT pg_terminate_backend(pg_stat_activity.pid)
+  FROM pg_stat_activity
+  WHERE pg_stat_activity.datname = $1
+    AND pid <> pg_backend_pid()`;
+
+export const COUNT_TABLES = `
+  SELECT COUNT(*) as count
+  FROM information_schema.tables
+  WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+    AND table_type = 'BASE TABLE'`;
+
+// ============================================
+// Migration Tracking
+// ============================================
+
+export const CREATE_MIGRATIONS_TABLE = `
+  CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+    version VARCHAR(128) NOT NULL PRIMARY KEY
+  )`;
+
+export const INSERT_MIGRATION_VERSION = `
+  INSERT INTO ${MIGRATIONS_TABLE} (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`;
+
+export const CHECK_MIGRATIONS_TABLE_EXISTS = `
+  SELECT 1 FROM information_schema.tables
+  WHERE table_schema = 'postkit' AND table_name = 'schema_migrations' LIMIT 1`;
+
+export const GET_APPLIED_VERSIONS = `SELECT version FROM ${MIGRATIONS_TABLE}`;
+
+// ============================================
+// Infra: Schemas & Roles
+// ============================================
+
+export const FETCH_SCHEMAS = `
+  SELECT nspname, pg_catalog.pg_get_userbyid(nspowner) AS owner
+  FROM pg_catalog.pg_namespace
+  WHERE nspname NOT LIKE 'pg_%'
+    AND nspname != 'information_schema'
+  ORDER BY nspname`;
+
+export const FETCH_ROLES = `
+  SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
+          rolcanlogin, rolreplication, rolconnlimit
+  FROM pg_catalog.pg_roles
+  WHERE rolname NOT LIKE 'pg_%'
+  ORDER BY rolname`;

--- a/cli/src/modules/db/services/database.ts
+++ b/cli/src/modules/db/services/database.ts
@@ -1,6 +1,12 @@
 import pg from "pg";
 import type {DatabaseConnectionInfo} from "../types/index";
 import {runPipedCommands} from "../../../common/shell";
+import {
+  TEST_CONNECTION,
+  CHECK_DB_EXISTS,
+  TERMINATE_CONNECTIONS,
+  COUNT_TABLES,
+} from "../config/queries";
 
 const {Client} = pg;
 
@@ -26,7 +32,7 @@ export async function testConnection(url: string): Promise<boolean> {
 
   try {
     await client.connect();
-    await client.query("SELECT 1");
+    await client.query(TEST_CONNECTION);
     return true;
   } catch {
     return false;
@@ -48,7 +54,7 @@ export async function createDatabase(url: string): Promise<void> {
 
     // Check if database exists
     const result = await client.query(
-      "SELECT 1 FROM pg_database WHERE datname = $1",
+      CHECK_DB_EXISTS,
       [targetDb],
     );
 
@@ -73,12 +79,7 @@ export async function dropDatabase(url: string): Promise<void> {
 
     // Terminate existing connections
     await client.query(
-      `
-      SELECT pg_terminate_backend(pg_stat_activity.pid)
-      FROM pg_stat_activity
-      WHERE pg_stat_activity.datname = $1
-        AND pid <> pg_backend_pid()
-    `,
+      TERMINATE_CONNECTIONS,
       [targetDb],
     );
 
@@ -149,12 +150,7 @@ export async function getTableCount(url: string): Promise<number> {
 
   try {
     await client.connect();
-    const result = await client.query(`
-      SELECT COUNT(*) as count
-      FROM information_schema.tables
-      WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-        AND table_type = 'BASE TABLE'
-    `);
+    const result = await client.query(COUNT_TABLES);
     return parseInt(result.rows[0].count, 10);
   } finally {
     await client.end();

--- a/cli/src/modules/db/services/dbmate.ts
+++ b/cli/src/modules/db/services/dbmate.ts
@@ -1,7 +1,6 @@
 import type {MigrationFile, ApplyResult} from "../types/index";
 import {runSpawnCommand, commandExists} from "../../../common/shell";
-import {getDbConfig} from "../utils/db-config";
-import {getCommittedMigrationsPath, getSessionMigrationsPath} from "../utils/db-config";
+import {getDbConfig, getCommittedMigrationsPath, getSessionMigrationsPath, MIGRATIONS_TABLE} from "../utils/db-config";
 import {formatTimestamp} from "../utils/session";
 import {getPostkitDir} from "../../../common/config";
 import fs from "fs/promises";
@@ -71,6 +70,7 @@ export async function runSessionMigrate(
     "--env-file", "/dev/null",
     "--url", databaseUrl,
     "--migrations-dir", sessionDir,
+    "--migrations-table", MIGRATIONS_TABLE,
     "up",
   ]);
 
@@ -102,6 +102,7 @@ export async function runCommittedMigrate(
     "--env-file", "/dev/null",
     "--url", databaseUrl,
     "--migrations-dir", targetDir,
+    "--migrations-table", MIGRATIONS_TABLE,
     "up",
   ]);
 
@@ -132,6 +133,7 @@ export async function runDbmateStatus(databaseUrl: string): Promise<string> {
     "--env-file", "/dev/null",
     "--url", databaseUrl,
     "--migrations-dir", getCommittedMigrationsPath(),
+    "--migrations-table", MIGRATIONS_TABLE,
     "status",
   ]);
 

--- a/cli/src/modules/db/services/pgschema.ts
+++ b/cli/src/modules/db/services/pgschema.ts
@@ -21,13 +21,15 @@ export async function checkPgschemaInstalled(): Promise<boolean> {
 export async function runPgschemaplan(
   schemaFile: string,
   databaseUrl: string,
+  schemaOverride?: string,
 ): Promise<PlanResult> {
   const config = getDbConfig();
   const planFile = getPlanFilePath();
   const dbInfo = parseConnectionUrl(databaseUrl);
+  const schema = schemaOverride || config.schema;
 
   // Run pgschema plan command (cwd set to schemaPath so .pgschemaignore is picked up)
-  const command = `${config.pgSchemaBin} plan --schema "${config.schema}" --file "${schemaFile}" --output-sql "${planFile}"`;
+  const command = `${config.pgSchemaBin} plan --schema "${schema}" --file "${schemaFile}" --output-sql "${planFile}"`;
   const result = await runCommand(command, {
     cwd: config.schemaPath,
     env: {

--- a/cli/src/modules/db/services/schema-importer.ts
+++ b/cli/src/modules/db/services/schema-importer.ts
@@ -399,6 +399,12 @@ export async function normalizeDumpForPostkit(
     await fs.writeFile(ignorePath, content, "utf-8");
   }
 
+  // Clean up schema.sql artifact that pgschema creates in parent of schemaPath
+  const artifact = path.join(path.dirname(schemaPath), "schema.sql");
+  if (existsSync(artifact)) {
+    await fs.unlink(artifact);
+  }
+
   return {filesCreated};
 }
 

--- a/cli/src/modules/db/services/schema-importer.ts
+++ b/cli/src/modules/db/services/schema-importer.ts
@@ -4,6 +4,13 @@ import path from "path";
 import {existsSync} from "fs";
 import {runCommand} from "../../../common/shell";
 import {getDbConfig, getTmpImportDir, MIGRATIONS_TABLE} from "../utils/db-config";
+import {
+  CREATE_POSTKIT_SCHEMA,
+  CREATE_MIGRATIONS_TABLE,
+  INSERT_MIGRATION_VERSION,
+  FETCH_SCHEMAS,
+  FETCH_ROLES,
+} from "../config/queries";
 import {parseConnectionUrl, createDatabase, dropDatabase} from "./database";
 import {runPgschemaplan} from "./pgschema";
 import {generateSchemaSQLAndFingerprint} from "./schema-generator";
@@ -233,11 +240,7 @@ export async function fetchInfraFromDatabase(
 
     // Fetch non-system schemas
     const schemaRows = await client.query<{nspname: string; owner: string}>(
-      `SELECT nspname, pg_catalog.pg_get_userbyid(nspowner) AS owner
-       FROM pg_catalog.pg_namespace
-       WHERE nspname NOT LIKE 'pg_%'
-         AND nspname != 'information_schema'
-       ORDER BY nspname`,
+      FETCH_SCHEMAS,
     );
 
     for (const row of schemaRows.rows) {
@@ -254,13 +257,7 @@ export async function fetchInfraFromDatabase(
       rolcanlogin: boolean;
       rolreplication: boolean;
       rolconnlimit: number;
-    }>(
-      `SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
-              rolcanlogin, rolreplication, rolconnlimit
-       FROM pg_catalog.pg_roles
-       WHERE rolname NOT LIKE 'pg_%'
-       ORDER BY rolname`,
-    );
+    }>(FETCH_ROLES);
 
     for (const row of roleRows.rows) {
       const attrs = [
@@ -502,20 +499,13 @@ export async function syncMigrationState(
     await client.connect();
 
     // Ensure postkit schema exists
-    await client.query(`CREATE SCHEMA IF NOT EXISTS postkit`);
+    await client.query(CREATE_POSTKIT_SCHEMA);
 
     // Create schema_migrations table in postkit schema
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
-        version VARCHAR(128) NOT NULL PRIMARY KEY
-      )
-    `);
+    await client.query(CREATE_MIGRATIONS_TABLE);
 
     // Insert the baseline version
-    await client.query(
-      `INSERT INTO ${MIGRATIONS_TABLE} (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`,
-      [version],
-    );
+    await client.query(INSERT_MIGRATION_VERSION, [version]);
   } finally {
     await client.end();
   }

--- a/cli/src/modules/db/services/schema-importer.ts
+++ b/cli/src/modules/db/services/schema-importer.ts
@@ -460,7 +460,7 @@ export async function generateBaselineDDL(
     const {schemaFile} = await generateSchemaSQLAndFingerprint();
 
     // Run pgschema plan against empty database — produces full CREATE DDL
-    const planResult = await runPgschemaplan(schemaFile, tmpDbUrl);
+    const planResult = await runPgschemaplan(schemaFile, tmpDbUrl, schemaName);
 
     if (!planResult.hasChanges || !planResult.planOutput) {
       throw new Error(

--- a/cli/src/modules/db/services/schema-importer.ts
+++ b/cli/src/modules/db/services/schema-importer.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 import {existsSync} from "fs";
 import {runCommand} from "../../../common/shell";
-import {getDbConfig, getTmpImportDir} from "../utils/db-config";
+import {getDbConfig, getTmpImportDir, MIGRATIONS_TABLE} from "../utils/db-config";
 import {parseConnectionUrl, createDatabase, dropDatabase} from "./database";
 import {runPgschemaplan} from "./pgschema";
 import {generateSchemaSQLAndFingerprint} from "./schema-generator";
@@ -471,7 +471,13 @@ export async function generateBaselineDDL(
       );
     }
 
-    return planResult.planOutput;
+    // Prepend SET search_path for non-public schemas
+    let ddl = planResult.planOutput;
+    if (schemaName !== "public") {
+      ddl = `SET search_path TO "${schemaName}";\n\n${ddl}`;
+    }
+
+    return ddl;
   } finally {
     // Always clean up the temp database
     try {
@@ -484,6 +490,7 @@ export async function generateBaselineDDL(
 
 /**
  * Insert a migration tracking record into the source database's schema_migrations table.
+ * Uses postkit.schema_migrations to keep migration tracking separate from user schemas.
  */
 export async function syncMigrationState(
   databaseUrl: string,
@@ -494,16 +501,19 @@ export async function syncMigrationState(
   try {
     await client.connect();
 
-    // Create schema_migrations table if it doesn't exist (dbmate format)
+    // Ensure postkit schema exists
+    await client.query(`CREATE SCHEMA IF NOT EXISTS postkit`);
+
+    // Create schema_migrations table in postkit schema
     await client.query(`
-      CREATE TABLE IF NOT EXISTS schema_migrations (
+      CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
         version VARCHAR(128) NOT NULL PRIMARY KEY
       )
     `);
 
     // Insert the baseline version
     await client.query(
-      "INSERT INTO schema_migrations (version) VALUES ($1) ON CONFLICT (version) DO NOTHING",
+      `INSERT INTO ${MIGRATIONS_TABLE} (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`,
       [version],
     );
   } finally {

--- a/cli/src/modules/db/utils/committed.ts
+++ b/cli/src/modules/db/utils/committed.ts
@@ -3,6 +3,10 @@ import {existsSync} from "fs";
 import pg from "pg";
 import type {CommittedState, CommittedMigration} from "../types/index";
 import {getCommittedFilePath, MIGRATIONS_TABLE} from "./db-config";
+import {
+  CHECK_MIGRATIONS_TABLE_EXISTS,
+  GET_APPLIED_VERSIONS,
+} from "../config/queries";
 import {logger} from "../../../common/logger";
 
 const {Client} = pg;
@@ -67,15 +71,13 @@ async function getAppliedMigrationVersions(remoteUrl: string): Promise<Set<strin
     await client.connect();
 
     // Check if migrations table exists in postkit schema
-    const tableCheck = await client.query(
-      `SELECT 1 FROM information_schema.tables WHERE table_schema = 'postkit' AND table_name = 'schema_migrations' LIMIT 1`,
-    );
+    const tableCheck = await client.query(CHECK_MIGRATIONS_TABLE_EXISTS);
 
     if (tableCheck.rows.length === 0) {
       return new Set();
     }
 
-    const result = await client.query(`SELECT version FROM ${MIGRATIONS_TABLE}`);
+    const result = await client.query(GET_APPLIED_VERSIONS);
     return new Set(result.rows.map((row: {version: string}) => row.version));
   } catch {
     return new Set();

--- a/cli/src/modules/db/utils/committed.ts
+++ b/cli/src/modules/db/utils/committed.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import {existsSync} from "fs";
 import pg from "pg";
 import type {CommittedState, CommittedMigration} from "../types/index";
-import {getCommittedFilePath} from "./db-config";
+import {getCommittedFilePath, MIGRATIONS_TABLE} from "./db-config";
 import {logger} from "../../../common/logger";
 
 const {Client} = pg;
@@ -57,7 +57,7 @@ export async function getAllCommittedMigrations(): Promise<CommittedMigration[]>
 }
 
 /**
- * Queries the schema_migrations table on a remote database
+ * Queries the postkit.schema_migrations table on a remote database
  * and returns the set of applied migration version timestamps.
  */
 async function getAppliedMigrationVersions(remoteUrl: string): Promise<Set<string>> {
@@ -66,16 +66,16 @@ async function getAppliedMigrationVersions(remoteUrl: string): Promise<Set<strin
   try {
     await client.connect();
 
-    // Check if schema_migrations table exists
+    // Check if migrations table exists in postkit schema
     const tableCheck = await client.query(
-      "SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations' LIMIT 1",
+      `SELECT 1 FROM information_schema.tables WHERE table_schema = 'postkit' AND table_name = 'schema_migrations' LIMIT 1`,
     );
 
     if (tableCheck.rows.length === 0) {
       return new Set();
     }
 
-    const result = await client.query("SELECT version FROM schema_migrations");
+    const result = await client.query(`SELECT version FROM ${MIGRATIONS_TABLE}`);
     return new Set(result.rows.map((row: {version: string}) => row.version));
   } catch {
     return new Set();

--- a/cli/src/modules/db/utils/db-config.ts
+++ b/cli/src/modules/db/utils/db-config.ts
@@ -15,6 +15,13 @@ import type {DbConfig, RemoteInputConfig} from "../types/config";
 export type {DbConfig, RemoteInputConfig, RemoteConfig, DbInputConfig} from "../types/config";
 
 // ============================================
+// Constants
+// ============================================
+
+/** dbmate migration tracking table (schema-qualified) */
+export const MIGRATIONS_TABLE = "postkit.schema_migrations";
+
+// ============================================
 // Zod Schemas for Validation
 // ============================================
 

--- a/cli/test/e2e/workflows/import-custom-schema.test.ts
+++ b/cli/test/e2e/workflows/import-custom-schema.test.ts
@@ -1,0 +1,285 @@
+import {describe, it, expect, beforeAll, afterAll} from "vitest";
+import fs from "fs";
+import path from "path";
+import {runCli} from "../helpers/cli-runner";
+import {
+  createTestProject,
+  cleanupTestProject,
+  type TestProject,
+} from "../helpers/test-project";
+import {
+  startPostgres,
+  stopPostgres,
+  type TestDatabase,
+} from "../helpers/test-database";
+import {executeSql, queryDatabase} from "../helpers/db-query";
+import {
+  verifyTablesExist,
+  verifyFunctionsExist,
+  verifyViewsExist,
+} from "../helpers/workflow";
+
+/**
+ * db import — custom schema (non-public)
+ *
+ * Seeds a PostgreSQL database with objects in a custom schema "myapp",
+ * then runs `db import --schema myapp` and verifies:
+ *   - Schema files are generated correctly
+ *   - Baseline migration includes SET search_path
+ *   - schema_migrations table is created in "postkit" schema (not public)
+ *   - Local DB is set up with the imported schema
+ *   - Seed data in custom schema is intact
+ */
+describe("db import — custom schema (non-public)", () => {
+  let db: TestDatabase;
+  let project: TestProject;
+
+  const CUSTOM_SCHEMA = "myapp";
+
+  // SQL to seed the database with objects in custom schema
+  const SCHEMA_SQL = `
+    CREATE SCHEMA IF NOT EXISTS ${CUSTOM_SCHEMA};
+
+    -- Function
+    CREATE FUNCTION ${CUSTOM_SCHEMA}.update_updated_at() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+    BEGIN NEW.updated_at = CURRENT_TIMESTAMP; RETURN NEW; END;
+    $$;
+
+    -- Table: category
+    CREATE TABLE ${CUSTOM_SCHEMA}.category (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name CHARACTER VARYING(100) NOT NULL,
+        is_deleted BOOLEAN DEFAULT false NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- Table: product
+    CREATE TABLE ${CUSTOM_SCHEMA}.product (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name CHARACTER VARYING(200) NOT NULL,
+        sku CHARACTER VARYING(50) NOT NULL,
+        category_id UUID NOT NULL REFERENCES ${CUSTOM_SCHEMA}.category(id) ON DELETE RESTRICT,
+        price DOUBLE PRECISION NOT NULL CHECK (price >= 0),
+        is_deleted BOOLEAN DEFAULT false NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- Trigger
+    CREATE TRIGGER update_category_timestamp
+        BEFORE UPDATE ON ${CUSTOM_SCHEMA}.category FOR EACH ROW
+        EXECUTE FUNCTION ${CUSTOM_SCHEMA}.update_updated_at();
+
+    -- View
+    CREATE VIEW ${CUSTOM_SCHEMA}.product_list AS
+    SELECT p.id, p.name, p.sku, p.price, c.name AS category_name
+    FROM ${CUSTOM_SCHEMA}.product p
+    JOIN ${CUSTOM_SCHEMA}.category c ON c.id = p.category_id
+    WHERE p.is_deleted = false;
+
+    -- Seed data
+    INSERT INTO ${CUSTOM_SCHEMA}.category (id, name) VALUES
+        ('a0000000-0000-0000-0000-000000000001'::UUID, 'Electronics'),
+        ('a0000000-0000-0000-0000-000000000002'::UUID, 'Furniture');
+    INSERT INTO ${CUSTOM_SCHEMA}.product (name, sku, category_id, price) VALUES
+        ('Laptop', 'SKU-001', 'a0000000-0000-0000-0000-000000000001'::UUID, 999.99),
+        ('Desk Chair', 'SKU-002', 'a0000000-0000-0000-0000-000000000002'::UUID, 299.99);
+  `;
+
+  beforeAll(async () => {
+    db = await startPostgres();
+    await executeSql(db.url, SCHEMA_SQL);
+
+    project = await createTestProject({
+      localDbUrl: db.url,
+      remoteDbUrl: db.url,
+      remoteName: "dev",
+    });
+
+    // Set custom schema in config
+    const configPath = project.configPath;
+    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    config.db.schema = CUSTOM_SCHEMA;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  });
+
+  afterAll(async () => {
+    if (project) await cleanupTestProject(project);
+    if (db) await stopPostgres(db);
+  });
+
+  // ── Step 1: Import ──────────────────────────────────────────────────
+
+  it("imports the custom schema database successfully", async () => {
+    const result = await runCli(
+      ["db", "import", "--force", "--name", "custom_schema_baseline", "--url", db.url, "--schema", CUSTOM_SCHEMA],
+      {cwd: project.rootDir, timeout: 90_000},
+    );
+    if (result.exitCode !== 0) {
+      console.log("IMPORT STDOUT:", result.stdout);
+      console.log("IMPORT STDERR:", result.stderr);
+    }
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("import complete");
+  });
+
+  // ── Step 2: Verify schema files ─────────────────────────────────────
+
+  it("creates tables/ directory with SQL files", () => {
+    const dir = path.join(project.schemaPath, "tables");
+    expect(fs.existsSync(dir)).toBe(true);
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".sql"));
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("creates functions/ directory with SQL files", () => {
+    const dir = path.join(project.schemaPath, "functions");
+    if (fs.existsSync(dir)) {
+      const files = fs.readdirSync(dir).filter((f) => f.endsWith(".sql"));
+      expect(files.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("creates views/ directory with SQL files", () => {
+    const dir = path.join(project.schemaPath, "views");
+    if (fs.existsSync(dir)) {
+      const files = fs.readdirSync(dir).filter((f) => f.endsWith(".sql"));
+      expect(files.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("table files contain category and product DDL", () => {
+    const dir = path.join(project.schemaPath, "tables");
+    const allSql = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith(".sql"))
+      .map((f) => fs.readFileSync(path.join(dir, f), "utf-8"))
+      .join("\n");
+    expect(allSql).toContain("category");
+    expect(allSql).toContain("product");
+  });
+
+  it("creates infra directory with ordered SQL files", () => {
+    const infraDir = path.join(project.schemaPath, "infra");
+    expect(fs.existsSync(infraDir)).toBe(true);
+    const files = fs.readdirSync(infraDir).filter((f) => f.endsWith(".sql"));
+    expect(files.length).toBeGreaterThan(0);
+    // Roles must come before schemas (001_ prefix)
+    const hasRoles = files.some((f) => f.includes("roles"));
+    const hasSchemas = files.some((f) => f.includes("schemas"));
+    if (hasRoles && hasSchemas) {
+      const rolesFile = files.find((f) => f.includes("roles"))!;
+      const schemasFile = files.find((f) => f.includes("schemas"))!;
+      expect(rolesFile.localeCompare(schemasFile)).toBeLessThan(0);
+    }
+  });
+
+  // ── Step 3: Verify baseline migration ───────────────────────────────
+
+  it("creates baseline migration file", () => {
+    const migrationsDir = path.join(project.dbDir, "migrations");
+    const files = fs.readdirSync(migrationsDir).filter((f) => f.endsWith(".sql"));
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("baseline migration includes SET search_path for custom schema", () => {
+    const migrationsDir = path.join(project.dbDir, "migrations");
+    const files = fs.readdirSync(migrationsDir).filter((f) => f.endsWith(".sql"));
+    const content = fs.readFileSync(
+      path.join(migrationsDir, files[0]!),
+      "utf-8",
+    );
+    expect(content).toContain(`SET search_path TO "${CUSTOM_SCHEMA}"`);
+    expect(content).toContain("CREATE TABLE");
+  });
+
+  // ── Step 4: Verify committed.json ──────────────────────────────────
+
+  it("committed.json tracks the baseline migration", async () => {
+    const committed = JSON.parse(
+      fs.readFileSync(path.join(project.dbDir, "committed.json"), "utf-8"),
+    );
+    expect(committed.migrations).toHaveLength(1);
+    expect(committed.migrations[0].description).toContain("Baseline import");
+  });
+
+  // ── Step 5: Verify schema_migrations in postkit schema ──────────────
+
+  it("creates schema_migrations in postkit schema", async () => {
+    const rows = await queryDatabase(
+      db.url,
+      "SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema = 'postkit' AND table_name = 'schema_migrations'",
+    );
+    expect(rows.length).toBe(1);
+  });
+
+  it("inserts baseline version in postkit.schema_migrations", async () => {
+    const rows = await queryDatabase(
+      db.url,
+      "SELECT version FROM postkit.schema_migrations",
+    );
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT create schema_migrations in public schema", async () => {
+    const rows = await queryDatabase(
+      db.url,
+      "SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'schema_migrations'",
+    );
+    expect(rows.length).toBe(0);
+  });
+
+  // ── Step 6: Verify local database state ────────────────────────────
+
+  it("local DB has tables in custom schema", async () => {
+    const rows = await queryDatabase(
+      db.url,
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = '${CUSTOM_SCHEMA}' AND table_type = 'BASE TABLE'
+       ORDER BY table_name`,
+    );
+    const tables = rows.map((r) => (r as {table_name: string}).table_name);
+    expect(tables).toContain("category");
+    expect(tables).toContain("product");
+  });
+
+  it("local DB has function in custom schema", async () => {
+    const rows = await queryDatabase(
+      db.url,
+      `SELECT routine_name FROM information_schema.routines
+       WHERE routine_schema = '${CUSTOM_SCHEMA}' AND routine_type = 'FUNCTION'
+       ORDER BY routine_name`,
+    );
+    const found = rows.map((r) => (r as {routine_name: string}).routine_name);
+    expect(found).toContain("update_updated_at");
+  });
+
+  it("local DB has view in custom schema", async () => {
+    const rows = await queryDatabase(
+      db.url,
+      `SELECT table_name FROM information_schema.views
+       WHERE table_schema = '${CUSTOM_SCHEMA}' AND table_name = $1`,
+      ["product_list"],
+    );
+    const found = rows.map((r) => (r as {table_name: string}).table_name);
+    expect(found).toContain("product_list");
+  });
+
+  // ── Step 7: Verify seed data intact ────────────────────────────────
+
+  it("seed data is intact in custom schema", async () => {
+    const categories = await queryDatabase(
+      db.url,
+      `SELECT COUNT(*)::int AS count FROM ${CUSTOM_SCHEMA}.category`,
+    );
+    expect(categories[0]?.count).toBeGreaterThanOrEqual(2);
+
+    const products = await queryDatabase(
+      db.url,
+      `SELECT COUNT(*)::int AS count FROM ${CUSTOM_SCHEMA}.product`,
+    );
+    expect(products[0]?.count).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/cli/test/modules/db/services/dbmate.test.ts
+++ b/cli/test/modules/db/services/dbmate.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../../../src/modules/db/utils/db-config", () => ({
   })),
   getSessionMigrationsPath: vi.fn(() => "/project/.postkit/db/session"),
   getCommittedMigrationsPath: vi.fn(() => "/project/.postkit/db/migrations"),
+  MIGRATIONS_TABLE: "postkit.schema_migrations",
 }));
 
 vi.mock("../../../../src/modules/db/utils/session", () => ({

--- a/cli/test/modules/db/services/pgschema.test.ts
+++ b/cli/test/modules/db/services/pgschema.test.ts
@@ -111,6 +111,20 @@ describe("pgschema", () => {
         runPgschemaplan("/schema.sql", "postgres://user:pass@host/db"),
       ).rejects.toThrow("pgschema plan failed");
     });
+
+    it("uses schemaOverride instead of config.schema when provided", async () => {
+      const commandSpy = vi.mocked(runCommand).mockResolvedValue({
+        stdout: "Changes found", stderr: "", exitCode: 0,
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue("CREATE TABLE foo (id int);");
+      vi.mocked(fs.writeFile).mockResolvedValue();
+      await runPgschemaplan("/schema.sql", "postgres://user:pass@host/db", "myapp");
+      expect(commandSpy).toHaveBeenCalledTimes(1);
+      const calledCommand = commandSpy.mock.calls[0]![0] as string;
+      expect(calledCommand).toContain('--schema "myapp"');
+      expect(calledCommand).not.toContain('--schema "public"');
+    });
   });
 
   describe("wrapPlanSQL()", () => {

--- a/cli/test/modules/db/utils/committed.test.ts
+++ b/cli/test/modules/db/utils/committed.test.ts
@@ -15,6 +15,7 @@ vi.mock("fs", () => ({
 
 vi.mock("../../../../src/modules/db/utils/db-config", () => ({
   getCommittedFilePath: vi.fn(() => "/project/.postkit/db/committed.json"),
+  MIGRATIONS_TABLE: "postkit.schema_migrations",
 }));
 
 vi.mock("../../../../src/common/logger", () => ({


### PR DESCRIPTION
# PR: Move migration tracking to `postkit` schema & custom schema support

**Branch:** `fix/schema-migrations-table` → `development`

---

## Summary

Moves `schema_migrations` table to `postkit` schema for isolation, adds `SET search_path` support for non-public schema imports, centralizes SQL queries, cleans up pgschema artifacts, and adds e2e test for custom schema import.

---

## Changes

### Migration tracking table in `postkit` schema

`schema_migrations` is now created in `postkit` schema instead of `public`, keeping migration tracking separate from user data.

- **`dbmate.ts`** — Added `--migrations-table postkit.schema_migrations` flag to all dbmate commands
- **`schema-importer.ts`** — `syncMigrationState()` creates `postkit` schema and `postkit.schema_migrations` table
- **`committed.ts`** — `getAppliedMigrationVersions()` queries `postkit.schema_migrations`
- **`db-config.ts`** — Added `MIGRATIONS_TABLE` constant

### Custom (non-public) schema support

- **`schema-importer.ts`** — `generateBaselineDDL()` prepends `SET search_path TO "<schema>"` for non-public schemas
- **`pgschema.ts`** — `runPgschemaplan()` accepts optional `schemaOverride` parameter for import workflows

### Centralized SQL queries

- **New file: `config/queries.ts`** — All raw SQL moved to named constants (`CREATE_POSTKIT_SCHEMA`, `CREATE_MIGRATIONS_TABLE`, `INSERT_MIGRATION_VERSION`, `FETCH_SCHEMAS`, `FETCH_ROLES`, `TEST_CONNECTION`, etc.)
- **`database.ts`** — Uses query constants from `queries.ts`
- **`schema-importer.ts`** — Uses query constants from `queries.ts`

### Clean up pgschema `schema.sql` artifact

Pgschema creates a `schema.sql` file in the parent of `schemaPath` during dump and plan. This artifact is now cleaned up:

- **`schema-importer.ts`** — `normalizeDumpForPostkit()` deletes artifact after normalizing dump output
- **`import.ts`** — Final cleanup deletes artifact after baseline generation

### Tests

- **New: `import-custom-schema.test.ts`** — E2E test for importing a database with custom schema `myapp` (16 test cases covering schema files, infra ordering, baseline with `SET search_path`, `postkit.schema_migrations`, local DB state, seed data)
- **`pgschema.test.ts`** — Added test for schema override parameter
- **`dbmate.test.ts`** — Updated mock with `MIGRATIONS_TABLE`
- **`committed.test.ts`** — Updated mock with `MIGRATIONS_TABLE`

### Documentation

- **`docs/db.md`** — Updated `db start`, `db deploy`, `db import` docs, session state JSON, and troubleshooting section

---

## Files Changed

| File | Change |
|------|--------|
| `src/modules/db/config/queries.ts` | **New** — Centralized SQL query constants |
| `src/modules/db/utils/db-config.ts` | Added `MIGRATIONS_TABLE` constant |
| `src/modules/db/services/dbmate.ts` | `--migrations-table postkit.schema_migrations` flag |
| `src/modules/db/services/pgschema.ts` | Added `schemaOverride` param to `runPgschemaplan()` |
| `src/modules/db/services/schema-importer.ts` | `postkit.schema_migrations`, `SET search_path`, query constants, artifact cleanup |
| `src/modules/db/services/database.ts` | Uses query constants from `queries.ts` |
| `src/modules/db/utils/committed.ts` | Queries `postkit.schema_migrations` |
| `src/modules/db/commands/import.ts` | Final cleanup of pgschema artifact |
| `test/e2e/workflows/import-custom-schema.test.ts` | **New** — 16 test cases for custom schema import |
| `test/modules/db/services/pgschema.test.ts` | Schema override test |
| `docs/db.md` | Updated docs |
| `package.json` | Version bump |

---

## Test Plan

- [x] Unit tests pass: `npx vitest run`
- [x] E2E tests pass: `npx vitest run --config vitest.e2e.config.ts`
- [x] New e2e test: import with `--schema myapp` generates correct files and `postkit.schema_migrations`
- [x] Verify: `dbmate` creates `schema_migrations` in `postkit` schema, not `public`
- [x] Verify: non-public schema import prepends `SET search_path` in baseline migration
- [x] Verify: no `schema.sql` artifact left in parent of schemaPath after import
